### PR TITLE
Add `HeaderGenerator.orderHeaders()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,21 +66,9 @@ HeaderGenerator randomly generates realistic browser headers based on specified 
 
 
 * [HeaderGenerator](#HeaderGenerator)
-    * [`static orderHeaders(headers, [order])`](#HeaderGenerator+orderHeaders)
     * [`new HeaderGenerator(options)`](#new_HeaderGenerator_new)
     * [`.getHeaders(options, requestDependentHeaders)`](#HeaderGenerator+getHeaders)
-
-
-* * *
-
-<a name="HeaderGenerator+orderHeaders"></a>
-
-#### `static orderHeaders(headers, [order])`
-
-| Param | Type | Description |
-| --- | --- | --- |
-| headers | <code>Object</code> | specifies known values of headers dependent on the particular request |
-| order | <code>string[]</code> | an array of ordered header names, optional (will be deducted from `user-agent`) |
+    * [`orderHeaders(headers, [order])`](#HeaderGenerator+orderHeaders)
 
 
 * * *
@@ -139,3 +127,11 @@ and their possible overrides provided here.
 
 * * *
 
+<a name="HeaderGenerator+orderHeaders"></a>
+
+#### `orderHeaders(headers, [order])`
+
+| Param | Type | Description |
+| --- | --- | --- |
+| headers | <code>Object</code> | specifies known values of headers dependent on the particular request |
+| order | <code>string[]</code> | an array of ordered header names, optional (will be deducted from `user-agent`) |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ HeaderGenerator randomly generates realistic browser headers based on specified 
 <a name="HeaderGenerator+getHeaders"></a>
 
 #### `headerGenerator.getHeaders(options, requestDependentHeaders)`
-Generates a single set of headers using a combination of the default options specified in the constructor
+Generates a single set of ordered headers using a combination of the default options specified in the constructor
 and their possible overrides provided here.
 
 
@@ -95,6 +95,21 @@ and their possible overrides provided here.
 | options | [<code>HeaderGeneratorOptions</code>](#HeaderGeneratorOptions) | specifies options that should be overridden for this one call |
 | requestDependentHeaders | <code>Object</code> | specifies known values of headers dependent on the particular request |
 
+* * *
+
+<a name="HeaderGenerator+getUnorderedHeaders"></a>
+
+#### `headerGenerator.getUnorderedHeaders(options, requestDependentHeaders)`
+Generates a single set of unordered headers using a combination of the default options specified in the constructor
+and their possible overrides provided here.\
+Returns an object with `generatedSample` and `order` properties.\
+The `order` property is an array with sorted headers that could be used to sort `generatedSample`.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | [<code>HeaderGeneratorOptions</code>](#HeaderGeneratorOptions) | specifies options that should be overridden for this one call |
+| requestDependentHeaders | <code>Object</code> | specifies known values of headers dependent on the particular request |
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,21 @@ HeaderGenerator randomly generates realistic browser headers based on specified 
 
 
 * [HeaderGenerator](#HeaderGenerator)
+    * [`static orderHeaders(headers, [order])`](#HeaderGenerator+orderHeaders)
     * [`new HeaderGenerator(options)`](#new_HeaderGenerator_new)
     * [`.getHeaders(options, requestDependentHeaders)`](#HeaderGenerator+getHeaders)
+
+
+* * *
+
+<a name="HeaderGenerator+orderHeaders"></a>
+
+#### `static orderHeaders(headers, [order])`
+
+| Param | Type | Description |
+| --- | --- | --- |
+| headers | <code>Object</code> | specifies known values of headers dependent on the particular request |
+| order | <code>string[]</code> | an array of ordered header names, optional (will be deducted from `user-agent`) |
 
 
 * * *
@@ -88,22 +101,6 @@ HeaderGenerator randomly generates realistic browser headers based on specified 
 #### `headerGenerator.getHeaders(options, requestDependentHeaders)`
 Generates a single set of ordered headers using a combination of the default options specified in the constructor
 and their possible overrides provided here.
-
-
-| Param | Type | Description |
-| --- | --- | --- |
-| options | [<code>HeaderGeneratorOptions</code>](#HeaderGeneratorOptions) | specifies options that should be overridden for this one call |
-| requestDependentHeaders | <code>Object</code> | specifies known values of headers dependent on the particular request |
-
-* * *
-
-<a name="HeaderGenerator+getUnorderedHeaders"></a>
-
-#### `headerGenerator.getUnorderedHeaders(options, requestDependentHeaders)`
-Generates a single set of unordered headers using a combination of the default options specified in the constructor
-and their possible overrides provided here.\
-Returns an object with `generatedSample` and `order` properties.\
-The `order` property is an array with sorted headers that could be used to sort `generatedSample`.
 
 
 | Param | Type | Description |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ HeaderGenerator randomly generates realistic browser headers based on specified 
 * [HeaderGenerator](#HeaderGenerator)
     * [`new HeaderGenerator(options)`](#new_HeaderGenerator_new)
     * [`.getHeaders(options, requestDependentHeaders)`](#HeaderGenerator+getHeaders)
-    * [`orderHeaders(headers, [order])`](#HeaderGenerator+orderHeaders)
+    * [`.orderHeaders(headers, order)`](#HeaderGenerator+orderHeaders)
 
 
 * * *
@@ -95,6 +95,21 @@ and their possible overrides provided here.
 | --- | --- | --- |
 | options | [<code>HeaderGeneratorOptions</code>](#HeaderGeneratorOptions) | specifies options that should be overridden for this one call |
 | requestDependentHeaders | <code>Object</code> | specifies known values of headers dependent on the particular request |
+
+
+* * *
+
+<a name="HeaderGenerator+orderHeaders"></a>
+
+#### `headerGenerator.orderHeaders(headers, order)`
+Returns a new object that contains ordered headers.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| headers | <code>object</code> | specifies known values of headers dependent on the particular request |
+| order | <code>Array.&lt;string&gt;</code> | an array of ordered header names, optional (will be deducted from `user-agent`) |
+
 
 * * *
 
@@ -127,11 +142,3 @@ and their possible overrides provided here.
 
 * * *
 
-<a name="HeaderGenerator+orderHeaders"></a>
-
-#### `orderHeaders(headers, [order])`
-
-| Param | Type | Description |
-| --- | --- | --- |
-| headers | <code>Object</code> | specifies known values of headers dependent on the particular request |
-| order | <code>string[]</code> | an array of ordered header names, optional (will be deducted from `user-agent`) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "header-generator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "NodeJs package for generating browser-like headers.",
   "author": {
     "name": "Apify",

--- a/src/header-generator.js
+++ b/src/header-generator.js
@@ -166,12 +166,34 @@ class HeaderGenerator {
     }
 
     /**
-     * Generates a single set of headers using a combination of the default options specified in the constructor
+     * Generates a single set of ordered headers using a combination of the default options specified in the constructor
      * and their possible overrides provided here.
      * @param {HeaderGeneratorOptions} options - specifies options that should be overridden for this one call
      * @param {Object} requestDependentHeaders - specifies known values of headers dependent on the particular request
      */
     getHeaders(options = {}, requestDependentHeaders = {}) {
+        const { generatedSample, order } = this.getUnorderedHeaders(options, requestDependentHeaders);
+
+        // Order the headers in an order depending on the browser
+        const orderedSample = {};
+        for (const attribute of order) {
+            if (attribute in generatedSample) {
+                orderedSample[attribute] = generatedSample[attribute];
+            }
+        }
+
+        return orderedSample;
+    }
+
+    /**
+     * Generates a single set of unordered headers using a combination of the default options specified in the constructor
+     * and their possible overrides provided here.
+     * Returns an object with `generatedSample` and `order` properties.
+     * The `order` property is an array with sorted headers that could be used to sort `generatedSample`.
+     * @param {HeaderGeneratorOptions} options - specifies options that should be overridden for this one call
+     * @param {Object} requestDependentHeaders - specifies known values of headers dependent on the particular request
+     */
+    getUnorderedHeaders(options = {}, requestDependentHeaders = {}) {
         ow(options, 'HeaderGeneratorOptions', ow.object.exactShape(headerGeneratorOptionsShape));
         const headerOptions = JSON.parse(JSON.stringify({ ...this.defaultOptions, ...options }));
         headerOptions.browsers = headerOptions.browsers.map((browserObject) => {
@@ -285,15 +307,10 @@ class HeaderGenerator {
 
         generatedSample = { ...generatedSample, ...requestDependentHeaders };
 
-        // Order the headers in an order depending on the browser
-        const orderedSample = {};
-        for (const attribute of headersOrder[generatedHttpAndBrowser.name]) {
-            if (attribute in generatedSample) {
-                orderedSample[attribute] = generatedSample[attribute];
-            }
-        }
-
-        return orderedSample;
+        return {
+            generatedSample,
+            order: headersOrder[generatedHttpAndBrowser.name],
+        };
     }
 }
 

--- a/src/header-generator.js
+++ b/src/header-generator.js
@@ -11,6 +11,7 @@ const headerNetworkDefinition = require('./data_files/header-network-definition.
 const inputNetworkDefinition = require('./data_files/input-network-definition.json');
 const headersOrder = require('./data_files/headers-order.json');
 const uniqueBrowserStrings = require('./data_files/browser-helper-file.json');
+const { getBrowser, getUserAgent } = require('./utils');
 
 const uniqueBrowsers = [];
 for (const browserString of uniqueBrowserStrings) {
@@ -110,25 +111,8 @@ const headerGeneratorOptionsShape = {
  * @returns {string[]} order
  */
 function getOrderFromUserAgent(headers) {
-    let userAgent = '';
-
-    for (const [key, value] of Object.entries(headers)) {
-        if (key.toLowerCase() === 'user-agent') {
-            userAgent = value;
-            break;
-        }
-    }
-
-    let browser;
-    if (userAgent.includes('Firefox')) {
-        browser = 'firefox';
-    } else if (userAgent.includes('Chrome')) {
-        browser = 'chrome';
-    } else if (userAgent.includes('Safari')) {
-        browser = 'safari';
-    } else {
-        return [];
-    }
+    const userAgent = getUserAgent(headers);
+    const browser = getBrowser(userAgent);
 
     return headersOrder[browser];
 }

--- a/src/header-generator.js
+++ b/src/header-generator.js
@@ -172,7 +172,7 @@ class HeaderGenerator {
      * @param {Object} requestDependentHeaders - specifies known values of headers dependent on the particular request
      */
     getHeaders(options = {}, requestDependentHeaders = {}) {
-        const { generatedSample, order } = this.getUnorderedHeaders(options, requestDependentHeaders);
+        const { generatedSample, order } = this.getRawHeadersAndOrder(options, requestDependentHeaders);
 
         // Order the headers in an order depending on the browser
         const orderedSample = {};
@@ -193,7 +193,7 @@ class HeaderGenerator {
      * @param {HeaderGeneratorOptions} options - specifies options that should be overridden for this one call
      * @param {Object} requestDependentHeaders - specifies known values of headers dependent on the particular request
      */
-    getUnorderedHeaders(options = {}, requestDependentHeaders = {}) {
+    getRawHeadersAndOrder(options = {}, requestDependentHeaders = {}) {
         ow(options, 'HeaderGeneratorOptions', ow.object.exactShape(headerGeneratorOptionsShape));
         const headerOptions = JSON.parse(JSON.stringify({ ...this.defaultOptions, ...options }));
         headerOptions.browsers = headerOptions.browsers.map((browserObject) => {

--- a/src/header-generator.js
+++ b/src/header-generator.js
@@ -109,6 +109,7 @@ const headerGeneratorOptionsShape = {
 /**
  * @param {object} headers - non-normalized request headers
  * @returns {string[]} order
+ * @private
  */
 function getOrderFromUserAgent(headers) {
     const userAgent = getUserAgent(headers);
@@ -304,8 +305,8 @@ class HeaderGenerator {
 
     /**
      * Returns a new object that contains ordered headers.
-     * @param {object} headers - request headers
-     * @param {string[]} order - array of ordered headers
+     * @param {object} headers - specifies known values of headers dependent on the particular request
+     * @param {string[]} order - an array of ordered header names, optional (will be deducted from `user-agent`)
      */
     orderHeaders(headers, order = getOrderFromUserAgent(headers)) {
         const orderedSample = {};

--- a/src/header-generator.js
+++ b/src/header-generator.js
@@ -173,7 +173,7 @@ class HeaderGenerator {
      * @param {string[]} sortedHeaders - array of headers in order
      * @returns header a or header b, depending which one is more important
      */
-    _sort(a, b, sortedHeaders) {
+    static _sort(a, b, sortedHeaders) {
         const rawA = sortedHeaders.indexOf(a);
         const rawB = sortedHeaders.indexOf(b);
         const indexA = rawA === -1 ? Number.POSITIVE_INFINITY : rawA;
@@ -195,8 +195,9 @@ class HeaderGenerator {
      * @param {string[]} sortedHeaders - array of headers in order
      * @returns {Function} - sort function
      */
-    createSort(sortedHeaders) {
-        const sortWithSortedHeaders = (a, b) => this._sort(a, b, sortedHeaders);
+    static createSort(sortedHeaders) {
+        // eslint-disable-next-line no-underscore-dangle
+        const sortWithSortedHeaders = (a, b) => HeaderGenerator._sort(a, b, sortedHeaders);
 
         return sortWithSortedHeaders;
     }
@@ -211,7 +212,7 @@ class HeaderGenerator {
         const { generatedSample, order } = this.generateHeadersAndOrder(options, requestDependentHeaders);
 
         // Order the headers in an order depending on the browser
-        return this.orderHeaders({
+        return HeaderGenerator.orderHeaders({
             ...generatedSample,
             ...requestDependentHeaders,
         }, order);
@@ -222,10 +223,10 @@ class HeaderGenerator {
      * @param {object} headers - request headers
      * @param {string[]} order - array of ordered headers
      */
-    orderHeaders(headers, order) {
+    static orderHeaders(headers, order) {
         const orderedSample = {};
         const keys = Object.keys(headers);
-        const sorted = keys.sort(this.createSort(order));
+        const sorted = keys.sort(HeaderGenerator.createSort(order));
 
         for (const key of sorted) {
             orderedSample[key] = headers[key];

--- a/src/header-generator.js
+++ b/src/header-generator.js
@@ -194,43 +194,6 @@ class HeaderGenerator {
     }
 
     /**
-     *
-     * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
-     * @param {string} a - header a
-     * @param {string} b - header b
-     * @param {string[]} sortedHeaders - array of headers in order
-     * @returns header a or header b, depending which one is more important
-     */
-    static _sort(a, b, sortedHeaders) {
-        const rawA = sortedHeaders.indexOf(a);
-        const rawB = sortedHeaders.indexOf(b);
-        const indexA = rawA === -1 ? Number.POSITIVE_INFINITY : rawA;
-        const indexB = rawB === -1 ? Number.POSITIVE_INFINITY : rawB;
-
-        if (indexA < indexB) {
-            return -1;
-        }
-
-        if (indexA > indexB) {
-            return 1;
-        }
-
-        return 0;
-    }
-
-    /**
-     *
-     * @param {string[]} sortedHeaders - array of headers in order
-     * @returns {Function} - sort function
-     */
-    static createSort(sortedHeaders) {
-        // eslint-disable-next-line no-underscore-dangle
-        const sortWithSortedHeaders = (a, b) => HeaderGenerator._sort(a, b, sortedHeaders);
-
-        return sortWithSortedHeaders;
-    }
-
-    /**
      * Generates a single set of ordered headers using a combination of the default options specified in the constructor
      * and their possible overrides provided here.
      * @param {HeaderGeneratorOptions} options - specifies options that should be overridden for this one call
@@ -349,7 +312,7 @@ class HeaderGenerator {
         }
 
         // Order the headers in an order depending on the browser
-        return HeaderGenerator.orderHeaders({
+        return this.orderHeaders({
             ...generatedSample,
             ...requestDependentHeaders,
         }, headersOrder[generatedHttpAndBrowser.name]);
@@ -360,13 +323,19 @@ class HeaderGenerator {
      * @param {object} headers - request headers
      * @param {string[]} order - array of ordered headers
      */
-    static orderHeaders(headers, order = getOrderFromUserAgent(headers)) {
+    orderHeaders(headers, order = getOrderFromUserAgent(headers)) {
         const orderedSample = {};
-        const keys = Object.keys(headers);
-        const sorted = keys.sort(HeaderGenerator.createSort(order));
 
-        for (const key of sorted) {
-            orderedSample[key] = headers[key];
+        for (const attribute of order) {
+            if (attribute in headers) {
+                orderedSample[attribute] = headers[attribute];
+            }
+        }
+
+        for (const attribute of Object.keys(headers)) {
+            if (!order.includes(attribute)) {
+                orderedSample[attribute] = headers[attribute];
+            }
         }
 
         return orderedSample;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,29 @@
+const getUserAgent = (headers) => {
+    let userAgent;
+    for (const [header, value] of Object.entries(headers)) {
+        if (header.toLowerCase() === 'user-agent') {
+            userAgent = value;
+            break;
+        }
+    }
+
+    return userAgent;
+};
+
+const getBrowser = (userAgent) => {
+    let browser;
+    if (userAgent.includes('Firefox')) {
+        browser = 'firefox';
+    } else if (userAgent.includes('Chrome')) {
+        browser = 'chrome';
+    } else {
+        browser = 'safari';
+    }
+
+    return browser;
+};
+
+module.exports = {
+    getUserAgent,
+    getBrowser,
+};

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -16,6 +16,14 @@ describe('Generation tests', () => {
         httpVersion: '2',
     });
 
+    test('Generates unordered headers', () => {
+        const result = headerGenerator.getUnorderedHeaders();
+
+        expect(result).toBeTruthy();
+        expect(result.generatedSample).toBeTruthy();
+        expect(Array.isArray(result.order)).toBe(true);
+    });
+
     test('Generates headers', () => {
         expect(headerGenerator.getHeaders()).toBeTruthy();
     });

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -1,4 +1,4 @@
-const {inspect} = require('util');
+const { inspect } = require('util');
 const HeaderGenerator = require('../src/main');
 const headersOrder = require('../src/data_files/headers-order.json');
 

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -86,6 +86,24 @@ describe('Generation tests', () => {
         expect(keys.indexOf('x-custom')).toBe(keys.length - 1);
     });
 
+    test('Orders headers', () => {
+        const headers = {
+            bar: 'foo',
+            foo: 'bar',
+            connection: 'keep-alive',
+        };
+
+        const order = [
+            'connection',
+            'foo',
+            'bar',
+        ];
+
+        const ordered = HeaderGenerator.orderHeaders(headers, order);
+        expect(ordered).toEqual(headers);
+        expect(Object.keys(ordered)).toEqual(order);
+    });
+
     test('Options from getHeaders override options from the constructor', () => {
         const headers = headerGenerator.getHeaders({
             httpVersion: '1',

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -17,7 +17,7 @@ describe('Generation tests', () => {
     });
 
     test('Generates unordered headers', () => {
-        const result = headerGenerator.getUnorderedHeaders();
+        const result = headerGenerator.getRawHeadersAndOrder();
 
         expect(result).toBeTruthy();
         expect(result.generatedSample).toBeTruthy();

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -91,7 +91,8 @@ describe('Generation tests', () => {
             'bar',
         ];
 
-        const ordered = HeaderGenerator.orderHeaders(headers, order);
+        const generator = new HeaderGenerator();
+        const ordered = generator.orderHeaders(headers, order);
         expect(ordered).toEqual(headers);
         expect(Object.keys(ordered)).toEqual(order);
     });
@@ -103,7 +104,8 @@ describe('Generation tests', () => {
             Connection: 'keep-alive',
         };
 
-        const ordered = HeaderGenerator.orderHeaders(headers);
+        const generator = new HeaderGenerator();
+        const ordered = generator.orderHeaders(headers);
         expect(ordered).toEqual(headers);
         expect(Object.keys(ordered)).toEqual(['Connection', 'user-agent', 'cookie']);
     });

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -44,7 +44,7 @@ describe('Generation tests', () => {
     });
 
     test('Generates unordered headers', () => {
-        const result = headerGenerator.getRawHeadersAndOrder();
+        const result = headerGenerator.generateHeadersAndOrder();
 
         expect(result).toBeTruthy();
         expect(result.generatedSample).toBeTruthy();
@@ -73,6 +73,17 @@ describe('Generation tests', () => {
 
             index = newIndex;
         }
+    });
+
+    test('Accepts custom headers', () => {
+        const headers = headerGenerator.getHeaders({
+            httpVersion: '1',
+        }, {
+            'x-custom': 'foobar',
+        });
+
+        const keys = Object.keys(headers);
+        expect(keys.indexOf('x-custom')).toBe(keys.length - 1);
     });
 
     test('Options from getHeaders override options from the constructor', () => {

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -43,14 +43,6 @@ describe('Generation tests', () => {
         httpVersion: '2',
     });
 
-    test('Generates unordered headers', () => {
-        const result = headerGenerator.generateHeadersAndOrder();
-
-        expect(result).toBeTruthy();
-        expect(result.generatedSample).toBeTruthy();
-        expect(Array.isArray(result.order)).toBe(true);
-    });
-
     test('Generates headers', () => {
         const headers = headerGenerator.getHeaders();
         const userAgent = getUserAgent(headers);
@@ -102,6 +94,18 @@ describe('Generation tests', () => {
         const ordered = HeaderGenerator.orderHeaders(headers, order);
         expect(ordered).toEqual(headers);
         expect(Object.keys(ordered)).toEqual(order);
+    });
+
+    test('Orders headers depending on user-agent', () => {
+        const headers = {
+            'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.36',
+            cookie: 'test=123',
+            Connection: 'keep-alive',
+        };
+
+        const ordered = HeaderGenerator.orderHeaders(headers);
+        expect(ordered).toEqual(headers);
+        expect(Object.keys(ordered)).toEqual(['Connection', 'user-agent', 'cookie']);
     });
 
     test('Options from getHeaders override options from the constructor', () => {

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -13,6 +13,31 @@ function extractLocalesFromAcceptLanguageHeader(acceptLanguageHeader) {
     return extractedLocales;
 }
 
+const getUserAgent = (headers) => {
+    let userAgent;
+    for (const [header, value] of Object.entries(headers)) {
+        if (header.toLowerCase() === 'user-agent') {
+            userAgent = value;
+            break;
+        }
+    }
+
+    return userAgent;
+};
+
+const getBrowser = (userAgent) => {
+    let browser;
+    if (userAgent.includes('Firefox')) {
+        browser = 'firefox';
+    } else if (userAgent.includes('Chrome')) {
+        browser = 'chrome';
+    } else {
+        browser = 'safari';
+    }
+
+    return browser;
+};
+
 describe('Generation tests', () => {
     const headerGenerator = new HeaderGenerator({
         httpVersion: '2',
@@ -28,23 +53,8 @@ describe('Generation tests', () => {
 
     test('Generates headers', () => {
         const headers = headerGenerator.getHeaders();
-
-        let userAgent;
-        for (const [header, value] of Object.entries(headers)) {
-            if (header.toLowerCase() === 'user-agent') {
-                userAgent = value;
-                break;
-            }
-        }
-
-        let browser;
-        if (userAgent.includes('Firefox')) {
-            browser = 'firefox';
-        } else if (userAgent.includes('Chrome')) {
-            browser = 'chrome';
-        } else {
-            browser = 'safari';
-        }
+        const userAgent = getUserAgent(headers);
+        const browser = getBrowser(userAgent);
 
         expect(typeof headers).toBe('object');
 


### PR DESCRIPTION
Required for `got-scraping`

Fixes #12