### PR TITLE
Do not crash when ordering and `user-agent` is missing

### DIFF
--- a/src/header-generator.js
+++ b/src/header-generator.js
@@ -115,6 +115,10 @@ function getOrderFromUserAgent(headers) {
     const userAgent = getUserAgent(headers);
     const browser = getBrowser(userAgent);
 
+    if (!browser) {
+        return [];
+    }
+
     return headersOrder[browser];
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,10 @@ const getUserAgent = (headers) => {
 };
 
 const getBrowser = (userAgent) => {
+    if (!userAgent) {
+        return;
+    }
+
     let browser;
     if (userAgent.includes('Firefox')) {
         browser = 'firefox';

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -102,6 +102,18 @@ describe('Generation tests', () => {
         expect(Object.keys(ordered)).toEqual(['Connection', 'user-agent', 'cookie']);
     });
 
+    test('Orders headers works without user-agent', () => {
+        const headers = {
+            cookie: 'test=123',
+            Connection: 'keep-alive',
+        };
+
+        const generator = new HeaderGenerator();
+        const ordered = generator.orderHeaders(headers);
+        expect(ordered).toEqual(headers);
+        expect(Object.keys(ordered)).toEqual(Object.keys(headers));
+    });
+
     test('Options from getHeaders override options from the constructor', () => {
         const headers = headerGenerator.getHeaders({
             httpVersion: '1',


### PR DESCRIPTION
Forgot this one case. Fixed in this PR.