### PR TITLE
feat: add support for TS Node16 module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "dependencies": {


### PR DESCRIPTION
This is the minimum requirement for supporting Node16 module/moduleResolution in TypeScript